### PR TITLE
Add eopkg (Solus) package manager support.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,8 @@ elif command -v apk &>/dev/null; then
 	check_dependencies "apk"
 elif command -v xbps-install &>/dev/null; then
 	check_dependencies "xbps-install"
+elif command -v eopkg &>/dev/null; then
+	check_dependencies "eopkg"
 elif command -v brew &>/dev/null; then
 	check_dependencies "brew"
 else


### PR DESCRIPTION
As easy as it sounds like. Curl and git are named as it is withing the package manager, so no issues there. Will obviously hurt with #23, but it's effortless to rebase it on that.
![image](https://github.com/catppuccin/steam/assets/13170204/a08ecb83-94ab-4eb1-a30a-1335fab8e60d)
Works fine on my end.